### PR TITLE
Remove RS String from sidebar

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -19,7 +19,6 @@
   - [OB3](./OB3.md)
 - [Class-Check](./Class-Check.md)
 - [Map-Region-System](./Map-Region-System.md)
-- [RS-String](./RS-String.md)
 - [Template-Packet](./Template-Packet.md)
 - [135-Protocol](./135-Protocol.md)
 - [194-Clear-screen](./194-Clear-screen.md)


### PR DESCRIPTION
It's already listed under "Data Types"